### PR TITLE
Add support for `guix shell`

### DIFF
--- a/guix.scm
+++ b/guix.scm
@@ -1,0 +1,26 @@
+(use-modules
+  (guix)
+  (guix build-system gnu)
+  ((guix licenses) #:prefix license:)
+  (gnu packages racket)
+  (gnu packages rust-apps)
+  (gnu packages version-control))
+
+(package
+  (name "racketower-db")
+  (version "1.0-git")
+  (source #f)
+  (build-system gnu-build-system)
+  (native-inputs
+    (list
+       racket
+       just
+       git))
+  (inputs
+    (list
+       ;; not sure if this is necessary
+       racket))
+  (synopsis "Toy database")
+  (home-page "https://github.com/Dr-Nekoma/RacketowerDB")
+  (license license:expat)
+  (description "Dr Nekoma's official database system.  Currently a toy database."))

--- a/guix.scm
+++ b/guix.scm
@@ -2,6 +2,8 @@
   (guix)
   (guix build-system gnu)
   ((guix licenses) #:prefix license:)
+  (gnu packages clojure)
+  (gnu packages emacs)
   (gnu packages racket)
   (gnu packages rust-apps)
   (gnu packages version-control))
@@ -14,6 +16,8 @@
   (native-inputs
     (list
        racket
+       clojure-tools
+       emacs
        just
        git))
   (inputs

--- a/info.rkt
+++ b/info.rkt
@@ -1,14 +1,24 @@
 #lang info
 (define collection "RacketowerDB")
-(define deps '("racket"
-	       "threading-lib"
-	       "beautiful-racket"
-	       "struct-update-lib"))
-(define build-deps '("scribble-lib"
-		     "racket-doc"
-		     "rackunit-lib"))
-(define scribblings '(("scribblings/RacketowerDB.scrbl" ())))
+
 (define pkg-desc "A simple database")
 (define version "1.0")
 (define pkg-authors '(lemos magueta))
 (define license '(MIT))
+
+(define deps
+  '("racket"
+    "threading-lib"
+    "beautiful-racket"
+    "struct-update-lib"))
+
+(define build-deps
+  '("scribble-lib"
+    "racket-doc"
+    "rackunit-lib"))
+
+(define compile-omit-files
+  '("guix.scm"))
+
+(define scribblings
+  '(("scribblings/RacketowerDB.scrbl" ())))


### PR DESCRIPTION
This adds `guix.scm`, which is basically equivalent to `flake.nix`. It also fixes the indentation of `info.rkt` and reorders some things in it because it was bothering me every time I looked at it.